### PR TITLE
Initialize Button

### DIFF
--- a/initializeScript/runAllCellsScript.ipynb
+++ b/initializeScript/runAllCellsScript.ipynb
@@ -1,0 +1,131 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<script>\n",
+       "    document.getElementById('toggleButton').onclick = function () {\n",
+       "        if (code_shown) {\n",
+       "            $('div.input').hide('500');\n",
+       "            $('#toggleButton').val('Show Code')\n",
+       "        } else {\n",
+       "            $('div.input').show('500');\n",
+       "            $('#toggleButton').val('Hide Code')\n",
+       "        }\n",
+       "        code_shown = !code_shown\n",
+       "    }\n",
+       "\n",
+       "    document.getElementById('init').onclick = function () {\n",
+       "        runAll = document.getElementById('run_all_cells_below').childNodes[1]\n",
+       "        runAll.click()\n",
+       "    }\n",
+       "\n",
+       "    $(document).ready(function () {\n",
+       "        code_shown = false;\n",
+       "        $('div.input').hide()\n",
+       "    });\n",
+       "</script>\n",
+       "<input type=\"submit\" id=\"toggleButton\" value=\"Show Code\">\n",
+       "<input id=\"init\" type=\"submit\" value=\"Initialize\">"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%html\n",
+    "<script>\n",
+    "    document.getElementById('toggleButton').onclick = function () {\n",
+    "        if (code_shown) {\n",
+    "            $('div.input').hide('500');\n",
+    "            $('#toggleButton').val('Show Code')\n",
+    "        } else {\n",
+    "            $('div.input').show('500');\n",
+    "            $('#toggleButton').val('Hide Code')\n",
+    "        }\n",
+    "        code_shown = !code_shown\n",
+    "    }\n",
+    "\n",
+    "    document.getElementById('init').onclick = function () {\n",
+    "        runAll = document.getElementById('run_all_cells_below').childNodes[1]\n",
+    "        runAll.click()\n",
+    "    }\n",
+    "\n",
+    "    $(document).ready(function () {\n",
+    "        code_shown = false;\n",
+    "        $('div.input').hide()\n",
+    "    });\n",
+    "</script>\n",
+    "<input type=\"submit\" id=\"toggleButton\" value=\"Show Code\">\n",
+    "<input id=\"init\" type=\"submit\" value=\"Initialize\">"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('This cell runs right away')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('This cell is waiting for an input, cells below will wait for this input to be entered before running')\n",
+    "i = input('Enter your name: ')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Hello '+i)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('and now this cell runs since the input cell is complete')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/initializeScript/runAllExample_ClimateChange.ipynb
+++ b/initializeScript/runAllExample_ClimateChange.ipynb
@@ -1,0 +1,452 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Climate change"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<script>\n",
+    "    document.getElementById('toggleButton').onclick = function () {\n",
+    "        if (code_shown) {\n",
+    "            $('div.input').hide('500');\n",
+    "            $('#toggleButton').val('Show Code')\n",
+    "        } else {\n",
+    "            $('div.input').show('500');\n",
+    "            $('#toggleButton').val('Hide Code')\n",
+    "        }\n",
+    "        code_shown = !code_shown\n",
+    "    }\n",
+    "\n",
+    "    document.getElementById('init').onclick = function () {\n",
+    "        runAll = document.getElementById('run_all_cells_below').childNodes[1]\n",
+    "        runAll.click()\n",
+    "    }\n",
+    "\n",
+    "    $(document).ready(function () {\n",
+    "        code_shown = false;\n",
+    "        $('div.input').hide()\n",
+    "    });\n",
+    "</script>\n",
+    "<input type=\"submit\" id=\"toggleButton\" value=\"Show Code\">\n",
+    "<input id=\"init\" type=\"submit\" value=\"Initialize\">"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<script>\n",
+    "    runAll = document.getElementById('run_all_cells_below').childNodes[1]\n",
+    "    runAll.click()\n",
+    "</script>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What do we know?\n",
+    "\n",
+    "The Earth's climate has been subject to changes throughout history and most of these can be attributed to variations in Earth's orbit resulting in the amount of solar energy that is received. The reason behind significant increase in warming trend since the industrial revolution is extremely likely to be the result of human activity.\n",
+    "\n",
+    "Earth is a complex intergrated system of components and processes. A disturbance in one component can have unprecedented and irreversible effects over another component. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## How do we know?\n",
+    "\n",
+    "Earth-orbiting satellites and other scientific advancements have made it possible to understand Earth on a global scale and have enabled scientists to collect many different types of information about our planet, its climate and use it to analyze how it has changed over the years. \n",
+    "\n",
+    "It is important to understand the evidence available for global climate change and the potential impacts it can cause in order to address the challenges that we may face. Knowing how these Earth systems have changed in the past and how they are changing in response to climate change now will help us understand how they will likely change in the future.\n",
+    "\n",
+    "Scientists gather data on global temperature, Carbon dioxide in the atmosphere, Arctic sea ice, land ice and sea level on a regular basis to analyze and understand how climate is changing over the years."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Evidence for rapid climate change"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Evidence 1 : Global Land-Ocean Termperature index\n",
+    "\n",
+    "\n",
+    "Data Source & Inspiration: NASA Global Climate Change, https://climate.nasa.gov/vital-signs/global-temperature/\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Below you can see a visualization created by NASA's scientific visualization studio showing the Global temperature anomalies from 1880 to 2017."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import YouTubeVideo\n",
+    "YouTubeVideo('xlrFFiSROmg')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import matplotlib as mpl\n",
+    "import matplotlib.pyplot as plt\n",
+    "from plotly.offline import init_notebook_mode, iplot\n",
+    "import plotly.graph_objs as go\n",
+    "from plotly.graph_objs import *"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = 'https://climate.nasa.gov/system/internal_resources/details/original/647_Global_Temperature_Data_File.txt'\n",
+    "\n",
+    "global_temperature_df = pd.read_table(url, sep='\\s+', header=None, names=['Year','Annual Mean', 'Lowess smoothing'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "global_temperature_df.tail(20)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "init_notebook_mode(connected=True)\n",
+    "\n",
+    "trace0 = go.Scatter(\n",
+    "    x = global_temperature_df['Year'],\n",
+    "    y = global_temperature_df['Annual Mean'],\n",
+    "    mode = 'lines+markers',\n",
+    "    name = 'Annual Mean'\n",
+    ")\n",
+    "\n",
+    "trace1 = go.Scatter(\n",
+    "    x = global_temperature_df['Year'],\n",
+    "    y = global_temperature_df['Lowess smoothing'],\n",
+    "    mode = 'lines+markers',\n",
+    "    name = 'Lowess smoothing'\n",
+    ")\n",
+    "\n",
+    "data = [trace0,trace1]\n",
+    "layout = go.Layout(dict(title='Global Land Ocean Temperature Index'),\n",
+    "                   xaxis=dict(title='Year'),\n",
+    "                   yaxis=dict(title='Temperature Anomaly')\n",
+    ")\n",
+    "fig = go.Figure(data=data,layout=layout)\n",
+    "iplot(fig)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This graph illustrates the change in global surface temperature relative to 1951-1980 average temperatures. Seventeen of the 18 warmest years in the 136-year record all have occurred since 2001, with the exception of 1998. The year 2016 ranks as the warmest on record. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By looking at the graph above and the video one can see that 2016 was the warmest year since modern record keeping began."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Questions\n",
+    "\n",
+    "The graph below illustrates the Annual average temperature departures from the 1961-1990 reference value (or the average temperatures recorded between 1961 to 1990) in Canada from 1948 to 2014. The data was obtained from Government of Canada's Open Data Portal: https://open.canada.ca/data/en/dataset/49118c5d-850c-40bd-af75-4f47650a9800\n",
+    "\n",
+    "Take a look at the graph and answer the questions that follow."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ca_url = 'https://www.canada.ca/content/dam/eccc/migration/main/indicateurs-indicators/64c9e931-fcc6-4df6-ad44-c2b0236fe255/temperaturechange_en.csv'\n",
+    "\n",
+    "ca_df = pd.read_table(ca_url, sep=\",\", skiprows=[0,1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "init_notebook_mode(connected=True)\n",
+    "\n",
+    "trace0 = go.Scatter(\n",
+    "    x = ca_df['Year'],\n",
+    "    y = ca_df['Temperature departure (degrees Celsius)'],\n",
+    "    mode = 'lines+markers',\n",
+    "    name = 'Annual Mean'\n",
+    ")\n",
+    "\n",
+    "trace1 = go.Scatter(\n",
+    "x = ca_df['Year'],\n",
+    "y = [0]*len(ca_df['Temperature departure (degrees Celsius)']),\n",
+    "mode = 'lines',\n",
+    "#opacity = 0.5,\n",
+    "name='Reference value',\n",
+    "hoverinfo = 'none'\n",
+    ")\n",
+    "data = [trace0, trace1]\n",
+    "layout = go.Layout(dict(title='Annual Average temperature departures in Canada'),\n",
+    "                   xaxis=dict(title='Year'),\n",
+    "                   yaxis=dict(title='Temperature Anomaly')\n",
+    ")\n",
+    "fig = go.Figure(data=data,layout=layout)\n",
+    "iplot(fig)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "1. What was the warmest and coldest year in Canada and by how much was it above or below the reference value?\n",
+    "2. Do you see a trend in the annual average temperature departure? Is it an upward or downward trend and what does it signify?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Evidence 2: Decline in extent and thickness of Arctic Sea Ice"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Scientists keep a close eye on Arctic sea ice as it warms through the years and it is found to be shrinking by about 13.2% per decade, relative to the 1981 to 2010 average.\n",
+    "\n",
+    "Decrease in both sea ice extent and area impacts a wide variety of marine lives that sustain in the Arctic right from single-celled algae to bowhead whales, polar bears and other mammals not excluding the indigenous people who rely on sea ice for transportation and hunting."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The data used below is a curated by NASA's global climate change intiative, originally pulled from National Snow and Ice Data Center."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = 'https://climate.nasa.gov/system/internal_resources/details/original/1270_minimum_extents_and_area_north_SBA_reg_20171001_2_.txt'\n",
+    "\n",
+    "arctic_ice_df = pd.read_table(url, sep='\\s+', skiprows=[0,1,2,3],header=None, names=['Year', 'MN', 'DY', 'Ice Extent', 'Year1', 'MN1', 'DY1', 'Ice Area'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "arctic_ice_df.head(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "init_notebook_mode(connected=True)\n",
+    "\n",
+    "trace0 = go.Scatter(\n",
+    "    x = arctic_ice_df['Year'],\n",
+    "    y = arctic_ice_df['Ice Extent'],\n",
+    "    mode = 'lines+markers',\n",
+    "    name = 'Ice Extent'\n",
+    ")\n",
+    "\n",
+    "trace1 = go.Scatter(\n",
+    "x = arctic_ice_df['Year'],\n",
+    "y = arctic_ice_df['Ice Area'],\n",
+    "mode = 'lines+markers',\n",
+    "#opacity = 0.5,\n",
+    "name='Ice Area',\n",
+    "#hoverinfo = 'none'\n",
+    ")\n",
+    "data = [trace0, trace1]\n",
+    "layout = go.Layout(dict(title='Arctic Sea Ice Index'),\n",
+    "                   xaxis=dict(title='Year'),\n",
+    "                   yaxis=dict(title='Million Square Kms')\n",
+    ")\n",
+    "fig = go.Figure(data=data,layout=layout)\n",
+    "iplot(fig)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Evidence 3: Sea level rise"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Global Mean Sea Level (GMSL) increases due to thermal expansion of water and by melting of ice sheets and glaciers on land \n",
+    "\n",
+    "The GMSL has risen by 10 to 20 centimeters over the past century and the annual rate of rise is at 3.2mm per year over the past 20years."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As Sea water level increases and reaches inland, it can cause erosion, more flooding, lost of habitat for fish, birds and plants. It also affects lives of millions of people who live in sea water flood prone low lying islands and other coastal regions."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Below you will see the data that illustrates changes in sea level since 1993 from NASA's satellite sea level observations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = 'ftp://podaac.jpl.nasa.gov/allData/merged_alt/L2/TP_J1_OSTM/global_mean_sea_level/GMSL_TPJAOS_4.2_199209_201801.txt'\n",
+    "\n",
+    "sea_level_df = pd.read_table(url, sep='\\s+', comment='H', header=None, usecols=[2,11], names=['Date','GMSL_variation'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import timedelta, datetime\n",
+    "\n",
+    "def convert_partial_year(number):\n",
+    "\n",
+    "    year = int(number)\n",
+    "    d = timedelta(days=(number - year)*365)\n",
+    "    day_one = datetime(year,1,1)\n",
+    "    date = d + day_one\n",
+    "    return date\n",
+    "\n",
+    "sea_level_df['Date'] = sea_level_df['Date'].apply(convert_partial_year)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sea_level_df.head(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "init_notebook_mode(connected=True)\n",
+    "\n",
+    "trace0 = go.Scatter(\n",
+    "    x = sea_level_df['Date'],\n",
+    "    y = sea_level_df['GMSL_variation']-sea_level_df['GMSL_variation'][1],\n",
+    "    mode = 'lines',\n",
+    "    name = 'Global Mean Sea level (GMSL) variation'\n",
+    ")\n",
+    "\n",
+    "data = [trace0]\n",
+    "layout = go.Layout(dict(title='Global Mean Sea level (GMSL) variation'),\n",
+    "                   xaxis=dict(title='Year'),\n",
+    "                   yaxis=dict(title='Sea height variation (mm)')\n",
+    ")\n",
+    "fig = go.Figure(data=data,layout=layout)\n",
+    "iplot(fig)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
I have added a small script to the existing "show/hide code" cell which adds a second button to initialize the entire notebook. All it does it run the "run all cells" from the drop down menu. I found that there was some confusion for newcomers to Jupiter notebooks when it comes to running the cells. Having this button is a good reminder to the user to run the cells before using the notebook. In this commit I have added the script to the existing "climate change" notebook to simulate how it works in a complete notebook. 