### PR TITLE
Geogebra hotfix

### DIFF
--- a/geogebra/geogebra/ggb.py
+++ b/geogebra/geogebra/ggb.py
@@ -44,8 +44,6 @@ class GGBOptions():
     def isStringType(key):
         return key in [
             'appName',
-            'width',
-            'height',
             'material_id',
             'filename',
             'ggBase64',
@@ -68,11 +66,6 @@ class GGBOptions():
             'height',
             'capturingThreshold',
             'scale',
-            'showAnimationButton',
-            'showFullscreenButton',
-            'showSuggestionButtons',
-            'showStartTooltip',
-            'butonShadows',
             'buttonRounding'
         ]
 
@@ -96,7 +89,12 @@ class GGBOptions():
             'enableCAS',
             'preventFocus',
             'allowUpscale',
-            'playButton'
+            'playButton',
+            'showAnimationButton',
+            'showFullscreenButton',
+            'showSuggestionButtons',
+            'showStartTooltip',
+            'buttonShadows'
         ]
 
 

--- a/geogebra/geogebra/ggb.py
+++ b/geogebra/geogebra/ggb.py
@@ -328,7 +328,9 @@ class GGBApi():
     @staticmethod
     def isSetter(fn):
         return fn in [
+            'setUndoPoint',
             'deleteObject',
+            'renameObject',
             'setAuxiliary',
             'setCaption',
             'setColor',
@@ -365,7 +367,6 @@ class GGBApi():
             'setErrorDialogsActive',
             'setCoordSystem',
             'setAxesVisible',
-            'setAxesVisible',
             'setAxisLabels',
             'setAxisSteps',
             'setAxisUnits',
@@ -386,13 +387,19 @@ class GGBApi():
             'setWidth',
             'setHeight',
             'setSize',
-            'recalculateEnvironments'
+            'recalculateEnvironments',
+            'setBase64',
+            'openFile',
+            'evalXML',
+            'setXML',
+            'debug'
         ]
 
     # Short aliases for the setter methods.
     @staticmethod
     def isSetterShort(fn):
         short = {
+            'UndoPoint': 'setUndoPoint',
             'Auxiliary': 'setAuxiliary',
             'Caption': 'setCaption',
             'Color': 'setColor',
@@ -431,7 +438,9 @@ class GGBApi():
             'Perspective': 'setPerspective',
             'Width': 'setWidth',
             'Height': 'setHeight',
-            'Size': 'setSize'
+            'Size': 'setSize',
+            'Base64': 'setBase64',
+            'XML': 'setXML'
         }
         if fn in short:
             return short[fn]
@@ -441,11 +450,14 @@ class GGBApi():
     @staticmethod
     def isGetter(fn):
         return fn in [
-            'renameObject',
+            'evalCommand',
+            'evalCommandGetLabels',
+            'evalCommandCAS',
             'getPNGBase64',
             'writePNGtoFile',
             'isIndependent',
             'isMoveable',
+            'getBase64',
             'isAnimationRunning',
             'getXcoord',
             'getYcoord',
@@ -476,7 +488,13 @@ class GGBApi():
             'getLabelVisible',
             'getMode',
             'getGridVisible',
-            'getPerspectiveXML'
+            'getPerspectiveXML',
+            'getXML',
+            'getAlgorithmXML',
+            'getVersion',
+            'getExerciseResult',
+            'getExerciseFraction',
+            'startExercise'
         ]
 
     # Short aliases for the getter methods.
@@ -484,6 +502,7 @@ class GGBApi():
     def isGetterShort(fn):
         short = {
             'PNGBase64': 'getPNGBase64',
+            'Base64': 'getBase64',
             'Xcoord': 'getXcoord',
             'Ycoord': 'getYcoord',
             'Zcoord': 'getZcoord',
@@ -511,7 +530,12 @@ class GGBApi():
             'LabelVisible': 'getLabelVisible',
             'Mode': 'getMode',
             'GridVisible': 'getGridVisible',
-            'PerspectiveXML': 'getPerspectiveXML'
+            'PerspectiveXML': 'getPerspectiveXML',
+            'XML': 'getXML',
+            'AlgorithmXML': 'getAlgorithmXML',
+            'Version': 'getVersion',
+            'ExerciseResult': 'getExerciseResult',
+            'ExerciseFraction': 'getExerciseFraction'
         }
         if fn in short:
             return short[fn]


### PR DESCRIPTION
Added some code to improve support for Run All Cells. There is still a bug when dealing with ggb.app() calls that I think is being caused by a race condition where a javascript library is loading other javascript libraries and there is no way to check if it has completed before allowing the applet to be loaded. That said, loading files and Material IDs with Run All seem to work fine as far as I can tell. There's also some error messages in case the javascript fails to load altogether for some reason (e.g. no internet connection).