### PR TITLE
Module for generating question widgets and callbacks

### DIFF
--- a/nbquestions/MANIFEST.in
+++ b/nbquestions/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md

--- a/nbquestions/README.md
+++ b/nbquestions/README.md
@@ -1,0 +1,64 @@
+# nbquestions
+
+## Usage
+
+### Multiple Choice
+
+``` python
+from nbquestions import create_multiple_choice
+
+def success():
+	print("Explanation for why the answer is correct...")
+
+widget = create_multiple_choice(["Correct", "Wrong", "Also Wrong", "Very Wrong"], success_callback=success)
+display(widget)
+```
+
+Creating a multiple choice question is easy. The only required argument is a
+list of two to five possible answers where the first element is assumed to be 
+the correct answer. The order of the answers is randomized before being
+displayed.
+
+You can also pass an optional callback that will be called when the correct
+answer is chosen. Usually you'll want to use this to provide an explanation of
+why the answer is correct. The example just prints text but you can do whatever
+you want, whether displaying math formulas with LaTeX or showing an image.
+
+### Text
+
+``` python
+import ipywidgets as widgets
+from nbquestions import create_text_callback
+
+def success():
+	print("Yes, George Orwell did write 1984!")
+	
+def failure():
+	print("Actually it was George Orwell who wrote 1984.")
+
+widget = widgets.Text(description="Who wrote the book 1984?", placeholder="Author's name")
+callback = create_text_callback("George Orwell", 3,
+	hints=["First name starts with G", "Last name starts with O"],
+	ignore_case=True, ignore_whitespace=True,
+	success_callback=success, failure_callback=failure)
+widget.on_submit(callback)
+display(widget)
+```
+
+For text responses, the helper function actually creates a callback intended to
+be passed to the `on_submit()` method of a text widget. The first argument is
+the answer and the second argument is the number of attempts allowed. These are
+the only required arguments, everything else is optional.
+
+Hints is a list of messages that will be displayed when the answer is incorrect.
+Ideally there should a number of hints equal to one less than the number of
+attempts. If there are less, the last hint will be repeated. If there are more,
+they will be ignored.
+
+You can also ignore case and whitespace (e.g. `GeOrgeorWELL` would be correct in
+this example). By default these are both set to `False`.
+
+Finally you can pass callbacks for when the user answers correctly or when
+they've used up all of their attempts. Generic success and failure messages are
+printed regardless so can pass the same function for both callbacks or none at
+all depending on your needs.

--- a/nbquestions/nbquestions/__init__.py
+++ b/nbquestions/nbquestions/__init__.py
@@ -1,0 +1,3 @@
+from nbquestions.nbquestions import create_text_callback, create_multiple_choice
+
+__all__ = ["create_text_callback", "create_multiple_choice"]

--- a/nbquestions/nbquestions/nbquestions.py
+++ b/nbquestions/nbquestions/nbquestions.py
@@ -1,0 +1,135 @@
+"""Helpful functions for common notebook tasks.
+
+This module provides helper functions to help reduce the amount of boilerplate
+code required for common notebook tasks. Currently it handles creating multiple
+choice questions and callbacks for text response questions.
+
+"""
+
+import random
+
+import ipywidgets as widgets
+
+
+def create_text_callback(answer, attempts, hints=None, ignore_case=False, ignore_whitespace=False,
+                         success_callback=None, failure_callback=None):
+    """Creates a callback for answering a question via a text widget.
+
+    If provided, the hints list should contain a number of hints equal to at
+    most one less than the number of attempts; any more will be ignored.
+
+    Args:
+        answer (str): The correct answer.
+        attempts (int): The maximum number of attempts allowed.
+        hints (List[str], optional): Messages to be displayed for incorrect answers.
+        ignore_case (bool, optional): Ignore case when checking if an answer is correct.
+        ignore_whitespace (bool, optional): Ignore whitespace when checking if an answer is correct.
+        success_callback (Callable, optional): Called when the correct answer is submitted.
+        failure_callback (Callable, optional): Called when all attempts have been used.
+
+    Returns:
+        Callable: Callback to provide to `on_submit` of a text widget.
+    """
+    def callback(widget):
+        nonlocal answer
+        answer_string = str(answer)
+        value = str(widget.value)
+
+        if ignore_case:
+            answer_string = answer_string.lower()
+            value = value.lower()
+        if ignore_whitespace:
+            answer_string = answer_string.replace(" ", "")
+            value = value.replace(" ", "")
+
+        if value == answer_string:
+            print("Correct!\n")
+            widget.disabled = True
+            if success_callback is not None:
+                success_callback()
+        else:
+            callback.attempt += 1
+            if callback.attempt >= attempts:
+                widget.disabled = True
+                if failure_callback is not None:
+                    print("Sorry, that's not right.\n")
+                    failure_callback()
+                else:
+                    print("Sorry, the correct answer is {}.".format(answer))
+            else:
+                print("Try again.\n")
+                hint = _get_hint(callback.attempt - 1, hints)
+                if hint is not None:
+                    print(hint + "\n")
+
+    callback.attempt = 0
+    return callback
+
+
+def create_multiple_choice(choices, answer=0, success_callback=None):
+    """Creates a widget for a multiple choice question.
+
+    Args:
+        choices (List[str]): The possible answers, up to a maximum of five.
+        answer (int, optional): The index of the correct answer in the ``choices`` list.
+        succes_callback (Callable, optional): Called when the correct answer is picked.
+
+    Returns:
+        HBox: Widget to be displayed.
+    """
+    letters = ["A", "B", "C", "D", "E"]
+    answer_text = choices[answer]
+
+    start_bold = "\033[1m"
+    end_bold = "\033[0;0m"
+
+    random.shuffle(choices)
+
+    for i, choice in enumerate(choices):
+        print(start_bold + letters[i] + ")" + end_bold + " " + choice)
+
+        if choice == answer_text:
+            answer = letters[i]
+
+    buttons = []
+
+    for i in range(len(choices)):
+        buttons.append(widgets.Button(description=letters[i]))
+
+    _reset_colours(buttons)
+
+    container = widgets.HBox(children=buttons)
+
+    def on_button_clicked(button):
+        _reset_colours(buttons)
+
+        if button.description == answer:
+            for b in buttons:
+                b.disabled = True
+            button.style.button_color = "Moccasin"
+            print("Correct!     \n")
+            if success_callback is not None:
+                success_callback()
+        else:
+            print("Try again.", end="\r")
+            button.style.button_color = "Lightgray"
+
+    for button in buttons:
+        button.on_click(on_button_clicked)
+
+    return container
+
+
+def _get_hint(attempt, hints):
+    if hints is None or not hints:
+        return None
+
+    if attempt >= len(hints):
+        return hints[-1]
+
+    return hints[attempt]
+
+
+def _reset_colours(buttons):
+    for button in buttons:
+        button.style.button_color = "Whitesmoke"

--- a/nbquestions/setup.py
+++ b/nbquestions/setup.py
@@ -1,0 +1,16 @@
+from setuptools import setup
+
+with open("README.md", "r") as f:
+    long_description = f.read()
+
+setup(name='nbquestions',
+      version='0.0.1',
+      description='Helper functions for creating questions',
+      long_description=long_description,
+      long_description_content_type="text/markdown",
+      url='http://github.com/callysto/nbplus',
+      author='Cameron Mann',
+      author_email='cameron.mann@cybera.ca',
+      license='MIT',
+      packages=['nbquestions'],
+      install_requires=[])


### PR DESCRIPTION
In reviewing and fixing up a number of abandonded notebooks, one of the recurring problems I've noticed is in building multiple choice and text response questions. Lots of repeated code is very common. I've also run into a handful of logic issues, especially with regards to all cells sharing the same global namespace.

This is my initial pass at starting a library of functions to help reduce boilerplate and bugs by handling most of the common logic for notebook creators. See the [readme](https://github.com/callysto/nbplus/blob/nbquestions/nbquestions/README.md) for full details of the functionality. There are a few points I'd like feedback on:

1. Multiple choice allows for 2-5 options. Should this be expanded to a more generic solution that can handle more options?
2. Do the callbacks for success/failure give enough flexibility to notebook creators?
3. Any other processing to provide beyond ignoring whitespace and case for text reponses?
4. I'm far from an expert on higher order functions in python so if there's anything I'm doing wrong or could be doing better please let me know.
5. Any other feedback.

Credit to @MattPalmarin whose code I adapted from one of his notebooks for the multiple choice code in this module.